### PR TITLE
fix pred_noise after clipping denoised

### DIFF
--- a/denoising_diffusion_pytorch/denoising_diffusion_pytorch.py
+++ b/denoising_diffusion_pytorch/denoising_diffusion_pytorch.py
@@ -583,6 +583,7 @@ class GaussianDiffusion(nn.Module):
 
             if clip_denoised:
                 x_start.clamp_(-1., 1.)
+                pred_noise = self.predict_noise_from_start(img, time_cond, x_start)
 
             if time_next < 0:
                 img = x_start


### PR DESCRIPTION
I've been comparing the recent changes to the DDIM sampling code against Glide's implementation to verify that it's doing the same thing given the same starting points and model (I used a simple random 1D model) and found that there might be a mistake in how clipping the denoised x_0 is being processed here.

In Glide's implementation, the predicted noise is being [recomputed](https://github.com/openai/glide-text2im/blob/main/glide_text2im/gaussian_diffusion.py#L482) after [clipping the predicted x_0](https://github.com/openai/glide-text2im/blob/main/glide_text2im/gaussian_diffusion.py#L253). In our implementation, we predict both x_0 and noise in .model_predictions() but then clip only x_start, which leaves pred_noise as it was and inconsistent with the x_start being used later to compute x_t-1. I'm not sure but I think it makes sense to update the predicted noise after clipping as well, and it's also what Glide does.