### PR TITLE
Trainer.load can use GPU's other than cuda:0

### DIFF
--- a/denoising_diffusion_pytorch/denoising_diffusion_pytorch.py
+++ b/denoising_diffusion_pytorch/denoising_diffusion_pytorch.py
@@ -810,7 +810,10 @@ class Trainer(object):
         torch.save(data, str(self.results_folder / f'model-{milestone}.pt'))
 
     def load(self, milestone):
-        data = torch.load(str(self.results_folder / f'model-{milestone}.pt'))
+        accelerator = self.accelerator
+        device = accelerator.device
+
+        data = torch.load(str(self.results_folder / f'model-{milestone}.pt'), map_location=device)
 
         model = self.accelerator.unwrap_model(self.model)
         model.load_state_dict(data['model'])


### PR DESCRIPTION
Hi! When I tried to load a checkpoint while using GPU 1 (because I'm sharing a computer with my other labmates), it decided to take up VRAM on both GPU 0 and GPU 1. This is because by default torch.load uses VRAM on cuda:0. I've added a fix; now this code will only use VRAM on the device set by the user.

```
#Code from https://github.com/lucidrains/denoising-diffusion-pytorch

import torch
from denoising_diffusion_pytorch import Unet, GaussianDiffusion, Trainer

dataset_path='/my/image/folder'


device=torch.device('cuda:1')
torch.cuda.set_device(device)

model = Unet(
    dim = 64,
    dim_mults = (1, 2, 4, 8)
).to(device)

diffusion = GaussianDiffusion(
    model,
    image_size = 128,
    timesteps = 1000,           # number of steps
    sampling_timesteps = 250,   # number of sampling timesteps (using ddim for faster inference [see citation for ddim paper])
    loss_type = 'l1'            # L1 or L2
).to(device)

trainer = Trainer(
    diffusion,
    dataset_path,
    train_batch_size = 32
    train_lr = 8e-5,
    train_num_steps = 700000,         # total training steps
    gradient_accumulate_every = 2,    # gradient accumulation steps
    ema_decay = 0.995,                # exponential moving average decay
    amp = False,                        # turn on mixed precision
    results_folder = './results',
)

trainer.load(11)

trainer.train()
```