### PR TITLE
Added gradient clipping.

### DIFF
--- a/denoising_diffusion_pytorch/denoising_diffusion_pytorch.py
+++ b/denoising_diffusion_pytorch/denoising_diffusion_pytorch.py
@@ -845,6 +845,7 @@ class Trainer(object):
 
                     self.accelerator.backward(loss)
 
+                accelerator.clip_grad_norm_(self.model.parameters(), 1.0)
                 pbar.set_description(f'loss: {total_loss:.4f}')
 
                 accelerator.wait_for_everyone()


### PR DESCRIPTION
This PR fixes #61 and #101.

I looked at the maximum of the model gradients during learning and often some gradients can become very big:
<img width="1265" alt="image" src="https://user-images.githubusercontent.com/11574848/194135702-64b36bb6-69ed-403d-9940-3c454a132638.png">

I added gradient clipping, which is also used by many other repositories of stable diffusion models.

The training loss is more stable, I didn't get the NaN problem with amp=True anymore (cyan is before PR, magenta is after):
<img width="1265" alt="image" src="https://user-images.githubusercontent.com/11574848/194135893-6b3fce1e-2674-419f-91d5-b35495d04af3.png">

I think this may also fix the loss divergence issues I encountered, but I haven't tested enough so far. It may be due to the high gradients shooting the model's weights somewhere where gradients are higher which leads to divergence. I saw someone else having [the same issue here](https://github.com/lucidrains/denoising-diffusion-pytorch/issues/4#issuecomment-860757983).