### PR TITLE
eta=0

### DIFF
--- a/denoising_diffusion_pytorch/denoising_diffusion_pytorch.py
+++ b/denoising_diffusion_pytorch/denoising_diffusion_pytorch.py
@@ -431,7 +431,7 @@ class GaussianDiffusion(nn.Module):
         beta_schedule = 'cosine',
         p2_loss_weight_gamma = 0., # p2 loss weight, from https://arxiv.org/abs/2204.00227 - 0 is equivalent to weight of 1 across time - 1. is recommended
         p2_loss_weight_k = 1,
-        ddim_sampling_eta = 1.
+        ddim_sampling_eta = 0.
     ):
         super().__init__()
         assert not (type(self) == GaussianDiffusion and model.channels != model.out_dim)

--- a/denoising_diffusion_pytorch/denoising_diffusion_pytorch_1d.py
+++ b/denoising_diffusion_pytorch/denoising_diffusion_pytorch_1d.py
@@ -414,7 +414,7 @@ class GaussianDiffusion1D(nn.Module):
         beta_schedule = 'cosine',
         p2_loss_weight_gamma = 0.,
         p2_loss_weight_k = 1,
-        ddim_sampling_eta = 1.
+        ddim_sampling_eta = 0.
     ):
         super().__init__()
         self.model = model


### PR DESCRIPTION
Shouldn't eta be 0 for DDIM sampling? In the DDIM paper in section 5.1 they mention the eta=0 is DDIM, and eta=1 approximates the normal DDPM. They also use [eta=0](https://github.com/openai/improved-diffusion/blob/e94489283bb876ac1477d5dd7709bbbd2d9902ce/improved_diffusion/gaussian_diffusion.py#L487) in the openai implementation of DDIM.

Maybe I'm missing something, but I figured I would make the PR just in case.