### PR TITLE
Fix self conditioning for elucidated diffusion

### DIFF
--- a/denoising_diffusion_pytorch/elucidated_diffusion.py
+++ b/denoising_diffusion_pytorch/elucidated_diffusion.py
@@ -194,7 +194,7 @@ class ElucidatedDiffusion(nn.Module):
                 images_next = images_hat + 0.5 * (sigma_next - sigma_hat) * (denoised_over_sigma + denoised_prime_over_sigma)
 
             images = images_next
-            x_start = model_output
+            x_start = model_output_next if sigma_next != 0 else model_output
 
         images = images.clamp(-1., 1.)
         return unnormalize_to_zero_to_one(images)


### PR DESCRIPTION
Hi lucidrains,

I think we should use the `D_\theta` output (i.e., preconditioned network output, `x_0` prediction) with the second order correction if possible. Otherwise, `model_output_next` is not used at all, and the self-conditioning signal in L182 is not the "latest" x_0 prediction. 

https://github.com/lucidrains/denoising-diffusion-pytorch/blob/aab2b04e95a266568ff768c8175d2c9bc1b66d4e/denoising_diffusion_pytorch/elucidated_diffusion.py#L180-L197

Please correct me if I'm wrong.

Thanks,
Qi
