### PR TITLE
Fix reduction to perform averaging

### DIFF
--- a/denoising_diffusion_pytorch/classifier_free_guidance.py
+++ b/denoising_diffusion_pytorch/classifier_free_guidance.py
@@ -750,7 +750,7 @@ class GaussianDiffusion(nn.Module):
             raise ValueError(f'unknown objective {self.objective}')
 
         loss = F.mse_loss(model_out, target, reduction = 'none')
-        loss = reduce(loss, 'b ... -> b (...)', 'mean')
+        loss = reduce(loss, 'b ... -> b', 'mean')
 
         loss = loss * extract(self.loss_weight, t, loss.shape)
         return loss.mean()

--- a/denoising_diffusion_pytorch/denoising_diffusion_pytorch.py
+++ b/denoising_diffusion_pytorch/denoising_diffusion_pytorch.py
@@ -790,7 +790,7 @@ class GaussianDiffusion(nn.Module):
             raise ValueError(f'unknown objective {self.objective}')
 
         loss = F.mse_loss(model_out, target, reduction = 'none')
-        loss = reduce(loss, 'b ... -> b (...)', 'mean')
+        loss = reduce(loss, 'b ... -> b', 'mean')
 
         loss = loss * extract(self.loss_weight, t, loss.shape)
         return loss.mean()

--- a/denoising_diffusion_pytorch/denoising_diffusion_pytorch_1d.py
+++ b/denoising_diffusion_pytorch/denoising_diffusion_pytorch_1d.py
@@ -700,7 +700,7 @@ class GaussianDiffusion1D(nn.Module):
             raise ValueError(f'unknown objective {self.objective}')
 
         loss = F.mse_loss(model_out, target, reduction = 'none')
-        loss = reduce(loss, 'b ... -> b (...)', 'mean')
+        loss = reduce(loss, 'b ... -> b', 'mean')
 
         loss = loss * extract(self.loss_weight, t, loss.shape)
         return loss.mean()

--- a/denoising_diffusion_pytorch/guided_diffusion.py
+++ b/denoising_diffusion_pytorch/guided_diffusion.py
@@ -751,7 +751,7 @@ class GaussianDiffusion(nn.Module):
             raise ValueError(f'unknown objective {self.objective}')
 
         loss = F.mse_loss(model_out, target, reduction = 'none')
-        loss = reduce(loss, 'b ... -> b (...)', 'mean')
+        loss = reduce(loss, 'b ... -> b', 'mean')
 
         loss = loss * extract(self.loss_weight, t, loss.shape)
         return loss.mean()


### PR DESCRIPTION
Hi @lucidrains,

Thank you for your great repos!
I found that `reduce` function works as `torch.flatten` in case of `GaussianDiffusion` implementations rather than averaging over last dimensions. Current PR fixes the typo and changes the `reduce` behaviour to averageing.
Hope it helps,
Cheers!