### PR TITLE
fix error for datasets with several channel numbers

### DIFF
--- a/denoising_diffusion_pytorch/denoising_diffusion_pytorch.py
+++ b/denoising_diffusion_pytorch/denoising_diffusion_pytorch.py
@@ -848,7 +848,7 @@ class Dataset(Dataset):
 
     def __getitem__(self, index):
         path = self.paths[index]
-        img = Image.open(path)
+        img = Image.open(path).convert("RGB")
         return self.transform(img)
 
 # trainer class


### PR DESCRIPTION
Datasets like ImageNet mix different image numbers (channels=1 for some images are grayscale, channels=4 for images in CMYK format). An error occurs when iterating the DataLoader.

The issue is solved by converting to RGB, similarly to `pil_loader` function in torchvision [ImageFolder](https://pytorch.org/vision/main/_modules/torchvision/datasets/folder.html) datasets.