### PR TITLE
Fix scale calculation in attention mechanism

### DIFF
--- a/denoising_diffusion_pytorch/attend.py
+++ b/denoising_diffusion_pytorch/attend.py
@@ -72,7 +72,7 @@ class Attend(nn.Module):
 
         if exists(self.scale):
             default_scale = q.shape[-1]
-            q = q * (scale / default_scale)
+            q = q * (self.scale / default_scale)
 
         q, k, v = map(lambda t: t.contiguous(), (q, k, v))
 


### PR DESCRIPTION
Modified the scale calculation in the attention mechanism to use the instance's scale value instead of a local variable. This change ensures that the scaling factor is consistent with the object's state.

Changed from:
if exists(self.scale):
    default_scale = q.shape[-1]
    q = q * (scale / default_scale)

To:
if exists(self.scale):
    default_scale = q.shape[-1]
    q = q * (self.scale / default_scale)