### PR TITLE
Extra Arg in Guided Diffusion

### DIFF
--- a/denoising_diffusion_pytorch/guided_diffusion.py
+++ b/denoising_diffusion_pytorch/guided_diffusion.py
@@ -151,7 +151,7 @@ class Block(nn.Module):
     def __init__(self, dim, dim_out):
         super().__init__()
         self.proj = nn.Conv2d(dim, dim_out, 3, padding = 1)
-        self.norm = RMSNorm(groups, dim_out)
+        self.norm = RMSNorm(dim_out)
         self.act = nn.SiLU()
 
     def forward(self, x, scale_shift = None):


### PR DESCRIPTION
```
from denoising_diffusion_pytorch.guided_diffusion import GaussianDiffusion, Unet

unet = Unet(dim=16, channels=3, out_dim=3)

diff = GaussianDiffusion(unet)
```

fails, because there is an extra argument, that doesn't seem to belong there.