### PR TITLE
Fix min-SNR loss weight clamp direction in continuous time diffusion

### DIFF
--- a/denoising_diffusion_pytorch/continuous_time_gaussian_diffusion.py
+++ b/denoising_diffusion_pytorch/continuous_time_gaussian_diffusion.py
@@ -261,7 +261,7 @@ class ContinuousTimeGaussianDiffusion(nn.Module):
 
         if self.min_snr_loss_weight:
             snr = log_snr.exp()
-            loss_weight = snr.clamp(min = self.min_snr_gamma) / snr
+            loss_weight = snr.clamp(max = self.min_snr_gamma) / snr
             losses = losses * loss_weight
 
         return losses.mean()


### PR DESCRIPTION
## Summary

The min-SNR-gamma strategy ([Hang et al., 2023](https://arxiv.org/abs/2303.09556)) computes loss weights as `min(SNR(t), gamma) / SNR(t)` to down-weight high-SNR (low-noise) timesteps during training.

In `continuous_time_gaussian_diffusion.py`, the clamp uses `min` instead of `max`:

```python
# Before (wrong) — computes max(SNR, gamma) / SNR
loss_weight = snr.clamp(min = self.min_snr_gamma) / snr

# After (correct) — computes min(SNR, gamma) / SNR
loss_weight = snr.clamp(max = self.min_snr_gamma) / snr
```

`torch.clamp(min=gamma)` gives `max(SNR, gamma)`, which inverts the intended behavior — it up-weights high-SNR timesteps rather than down-weighting them. The fix changes this to `clamp(max=gamma)` which gives `min(SNR, gamma)`, matching the paper and all other diffusion modules in this repo (e.g., `denoising_diffusion_pytorch.py`, `simple_diffusion.py`, `classifier_free_guidance.py`, etc. all correctly use `clamp_(max=...)`).